### PR TITLE
Proper plugin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,8 @@
-{plugins, [rebar3_proper]}.
 {proper_opts, [{numtests,100}, {dir, "test"}]}.
 
 {profiles, [
   {test, [
+    {plugins, [rebar3_proper]},
     {deps, [proper]}
   ]},
   {bench, [

--- a/src/merklet.app.src
+++ b/src/merklet.app.src
@@ -3,4 +3,8 @@
   {vsn, "1.0.0"},
   {modules, [merklet]},
   {registered, []},
-  {applications, [kernel, stdlib, crypto]}]}.
+  {applications, [kernel, stdlib, crypto]},
+
+  {licenses, ["MIT"]},
+  {maintainers, ["Fred Hebert"]},
+  {links, [{"github", "https://github.com/ferd/merklet"}]}]}.


### PR DESCRIPTION
Move the proper plugin into proper place - the test profile so it's not fetched by builds (as it's not needed)
